### PR TITLE
fix(krb5): fix CVE-2026-40355 and CVE-2026-40356

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+krb5 (1.20.1-5deepin2) unstable; urgency=medium
+
+  * Fix CVE-2026-40355: null pointer dereference in NegoEx parsing
+    Upstream commit:
+    https://github.com/krb5/krb5/commit/2e75f0d9362fb979f5fc92829431a590
+    a130929f
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 11 Jun 2026 22:30:36 +0800
+
 krb5 (1.20.1-5deepin1) unstable; urgency=medium
 
   * chore: build add nocheck option support

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+krb5 (1.20.1-5deepin3) unstable; urgency=medium
+
+  * Fix CVE-2026-40356: read overrun in NegoEx parsing  Upstream commit:
+    https://github.com/krb5/krb5/commit/2e75f0d9362fb979f5fc92829431a590
+    a130929f
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 11 Jun 2026 22:30:53 +0800
+
 krb5 (1.20.1-5deepin2) unstable; urgency=medium
 
   * Fix CVE-2026-40355: null pointer dereference in NegoEx parsing

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ debian-local/0008-Use-isystem-for-include-paths.patch
 0009-Add-.gitignore.patch
 upstream/0010-Ensure-array-count-consistency-in-kadm5-RPC.patch
 upstream/0011-Work-around-Doxygen-1.9.7-change.patch
+upstream/CVE-2026-40355-fix-null-deref-in-negoex-parse.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@ debian-local/0008-Use-isystem-for-include-paths.patch
 upstream/0010-Ensure-array-count-consistency-in-kadm5-RPC.patch
 upstream/0011-Work-around-Doxygen-1.9.7-change.patch
 upstream/CVE-2026-40355-fix-null-deref-in-negoex-parse.patch
+upstream/CVE-2026-40356-fix-read-overrun-in-negoex-parse.patch

--- a/debian/patches/upstream/CVE-2026-40355-fix-null-deref-in-negoex-parse.patch
+++ b/debian/patches/upstream/CVE-2026-40355-fix-null-deref-in-negoex-parse.patch
@@ -1,0 +1,15 @@
+Index: fix-krb5/src/lib/gssapi/spnego/negoex_util.c
+===================================================================
+--- fix-krb5.orig/src/lib/gssapi/spnego/negoex_util.c
++++ fix-krb5/src/lib/gssapi/spnego/negoex_util.c
+@@ -253,6 +253,10 @@ parse_nego_message(OM_uint32 *minor, str
+     offset = k5_input_get_uint32_le(in);
+     count = k5_input_get_uint16_le(in);
+     p = vector_base(offset, count, EXTENSION_LENGTH, msg_base, msg_len);
++    if (p == NULL) {
++        *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
++        return GSS_S_DEFECTIVE_TOKEN;
++    }
+     for (i = 0; i < count; i++) {
+         extension_type = load_32_le(p + i * EXTENSION_LENGTH);
+         if (extension_type & EXTENSION_FLAG_CRITICAL) {

--- a/debian/patches/upstream/CVE-2026-40356-fix-read-overrun-in-negoex-parse.patch
+++ b/debian/patches/upstream/CVE-2026-40356-fix-read-overrun-in-negoex-parse.patch
@@ -1,0 +1,14 @@
+Index: fix-krb5/src/lib/gssapi/spnego/negoex_util.c
+===================================================================
+--- fix-krb5.orig/src/lib/gssapi/spnego/negoex_util.c
++++ fix-krb5/src/lib/gssapi/spnego/negoex_util.c
+@@ -395,7 +395,8 @@ parse_message(OM_uint32 *minor, spnego_g
+     msg_len = k5_input_get_uint32_le(in);
+     conv_id = k5_input_get_bytes(in, GUID_LENGTH);
+ 
+-    if (in->status || msg_len > token_remaining || header_len > msg_len) {
++    if (in->status || msg_len > token_remaining ||
++        header_len < (size_t)(in->ptr - msg_base) || header_len > msg_len) {
+         *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
+         return GSS_S_DEFECTIVE_TOKEN;
+     }


### PR DESCRIPTION
Fix CVE-2026-40355 and CVE-2026-40356 in krb5 package.

## Changes

- **CVE-2026-40355**: Fix null pointer dereference in NegoEx parsing
- **CVE-2026-40356**: Fix read overrun in NegoEx parsing

Both CVEs affect `parse_nego_message()` and `parse_message()` in `src/lib/gssapi/spnego/negoex_util.c`.

## Patch Details

- CVE-2026-40355: Added NULL check after `vector_base()` call in `parse_nego_message()`
- CVE-2026-40356: Added bounds check for `header_len` in `parse_message()`

Upstream commit: https://github.com/krb5/krb5/commit/2e75f0d9362fb979f5fc92829431a590a130929f

Co-Authored-By: hudeng <hudeng@deepin.org>